### PR TITLE
Add -e flag in deploy script for Ranger service.

### DIFF
--- a/scripts/deploy-ranger-service.sh
+++ b/scripts/deploy-ranger-service.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 # Store xtrace status. Need to restore this after set +x.
 ORIGINALXTRACE=$(shopt -po xtrace)
 


### PR DESCRIPTION
Let the script stop immediately if encounter any error.