### PR TITLE
Move -e flag below store xtrace

### DIFF
--- a/scripts/deploy-ranger-service.sh
+++ b/scripts/deploy-ranger-service.sh
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 # Store xtrace status. Need to restore this after set +x.
 ORIGINALXTRACE=$(shopt -po xtrace)
+
+# Exit if error
+set -e
 
 PROJECT_ROOT=$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )")
 source $PROJECT_ROOT/scripts/project-settings.sh


### PR DESCRIPTION
The store xtrace command exit with 1, which make bash thinks it
encounter errors.